### PR TITLE
messages can be buffered and concatenated into a single slack post

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ pm2 set pm2-slack:log true
 pm2 set pm2-slack:error false
 ```
 
+## Options
+
+The following options are available:
+
+- buffer (bool) - Set to true to enable buffering of messages by timestamp.  Messages that occur with the same timestamp (seconds) will be concatenated together and posted as a single slack message. Default: false
+- buffer_seconds (int) - Duration in seconds to aggregate messages.  Has no effect if buffer is set to false.  Min: 1, Max: 5, Default: 1
+- queue_max (int) - Number of messages to keep queued before the queue will be truncated.  When the queue exceeds this maximum, a rate limit message will be posted to slack. Min: 10, Max: 100, Default: 100
+
+Set these options in the same way you subscribe to events.
+
+Example: The following configuration options will enable message buffering, and set the buffer duration to 2 seconds.  All messages that occur within 2 seconds of each other (for the same event) will be concatenated into a single slack message.
+
+```
+pm2 set pm2-slack:buffer true
+pm2 set pm2-slack:buffer_seconds 2
+```
+
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code.

--- a/index.js
+++ b/index.js
@@ -85,7 +85,6 @@ function bufferMessage() {
     nextMessage.buffer = [nextMessage.description];
   
     // continue shifting elements off the queue while they are the same event and timestamp so they can be buffered together into a single request
-    // @TODO: allow buffer length to be longer than 1s
     while (messages.length 
         && (messages[0].timestamp >= nextMessage.timestamp && messages[0].timestamp < (nextMessage.timestamp + conf.buffer_seconds))
         && messages[0].event === nextMessage.event) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "restart overlimit": true,
     "exit": false,
     "start": false,
-    "online": false
+    "online": false,
+	"buffer": false,
+	"buffer_seconds": 1,
+	"queue_max": 100
   }
 }


### PR DESCRIPTION
pm2-slack was dropping a considerable number of messages due to the rate limiting, so this PR allows them to be concatenated into a single message by timestamp.  it can be toggled via a config option.
- added bufferMessage fn to join log entries at the same timestamp before posting to slack
- added buffering to all events
- added configuration options:
  - buffer (default: false)
  - buffer_seconds (default: 1, only applicable if buffer is true)
  - queue_max (default: 100)
- updated README with new options
- added defaults to package.json config
