### PR TITLE
Fix: Double escaping of error and log messages.

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ pm2.launchBus(function(err, bus) {
                 messages.push({
                     name: data.process.name,
                     event: 'log',
-                    description: JSON.stringify(data.data),
+                    description: data.data,
                     timestamp: Math.floor(Date.now() / 1000),
                 });
             }
@@ -161,7 +161,7 @@ pm2.launchBus(function(err, bus) {
                 messages.push({
                     name: data.process.name,
                     event: 'error',
-                    description: JSON.stringify(data.data),
+                    description: data.data,
                     timestamp: Math.floor(Date.now() / 1000),
                 });
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-slack",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A PM2 module to emit events to Slack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In `bus.on('log:err', function(data) ...` and `bus.on('log:out', function(data) ...` the
`data.data` property is a `string`.

Current version 0.3.0 causes that messages are in quotation marks and new lines are converted into `\n` text because of double escaping of string.