### PR TITLE
Bugfix messages width

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+- 0.3.2 Fixed Half width of error and log messages (thanks @ma-zal)
 - 0.3.1 Fixed Double escaping of error and log messages (thanks @ma-zal)
 - 0.3.0 Switched to a default buffer system that groups alike messages by timestamp in the same message to Slack (thanks @kjhangiani)
 - 0.2.0 Implemented a rate limiting system and updated all the dependencies

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function sendSlack(message) {
             fields: [{
                 title: name + ' - ' + event,
                 value: description,
-                short: true
+                short: false
             }]
         }]
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-slack",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A PM2 module to emit events to Slack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Longer messages was displayed on left side of display only. Right was always empty. Reason is using property "short: true", that is used for displaying side-by-side with other values.

See documentation: 
https://api.slack.com/docs/message-attachments#fields