### PR TITLE
New buffering algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,24 @@ To get the Slack URL, you need to setup an Incoming Webhook. More details on how
 
 The following events can be subscribed to:
 
-- log - All standard out logs from your processes. Default: false
-- error - All error logs from your processes. Default: true
-- kill - Event fired when PM2 is killed. Default: true
-- exception - Any exceptions from your processes. Default: true
-- restart - Event fired when a process is restarted. Default: false
-- reload - Event fired when a cluster is reloaded. Default: false
-- delete - Event fired when a process is removed from PM2. Default: false
-- stop - Event fired when a process is stopped. Default: false
-- restart overlimit - Event fired when a process is reaches the max amount of times it can restart. Default: true
-- exit - Event fired when a process is exited. Default: false
-- start -  Event fired when a process is started. Default: false
-- online - Event fired when a process is online. Default: false
+| Event               | Description                                                                  | Default value | 
+|---------------------|------------------------------------------------------------------------------|---------------|
+| `log`               | All standard out logs from your processes                                    | false         |
+| `error`             | All error logs from your processes                                           | true          |
+| `kill`              | Event fired when PM2 is killed                                               | true          |
+| `exception`         | Any exceptions from your processes                                           | true          |
+| `restart`           | Event fired when a process is restarted                                      | false         |
+| `reload`            | Event fired when a cluster is reloaded.                                      | false         |
+| `delete`            | Event fired when a process is removed from PM2                               | false         |
+| `stop`              | Event fired when a process is stopped                                        | false         |
+| `restart overlimit` | Event fired when a process is reaches the max amount of times it can restart | true          |
+| `exit`              | Event fired when a process is exited                                         | false         |
+| `start`             | Event fired when a process is started                                        | false         |
+| `online`            | Event fired when a process is online                                         | false         |
 
 You can simply turn these on and off by setting them to true or false using the PM2 set command.
+
+##### Example
 
 ```
 pm2 set pm2-slack:log true
@@ -41,25 +45,39 @@ pm2 set pm2-slack:error false
 
 The following options are available:
 
-- buffer (bool) - Enable/Disable buffering of messages by timestamp. Messages that occur with the same timestamp (seconds) will be concatenated together and posted as a single slack message. Default: true
-- buffer_seconds (int) - Duration in seconds to aggregate messages. Has no effect if buffer is set to false.  Min: 1, Max: 5, Default: 1
-- queue_max (int) - Number of messages to keep queued before the queue will be truncated. When the queue exceeds this maximum, a rate limit message will be posted to slack. Min: 10, Max: 100, Default: 100
+| Key                  | type   | Desciption                                         | Default |
+|----------------------|--------|----------------------------------------------------|---------|
+| `buffer`             | bool   | Enable/Disable buffering of messages. Messages that occur in short time will be posted as a single slack message. | true |
+| `buffer_seconds`     | int    | If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* | 1 |
+| `buffer_max_seconds` | int    | If time exceed this time, the buffered messages are always sent to Slact, even if new messages are still comming in interval (property `buffer_seconds`). | 60 |
+| `queue_max`          | int    | Maximum number of messages, that can be send in one Slack message (in one bufferring round). When the queue exceeds this maximum, next messages are suppresesed and replaced with message "`Next XX messages have been suppressed.`". | 100 |
+| `servername`         | string | Server name, that will be used in each message as author. | {{Hostname}}
 
 Set these options in the same way you subscribe to events.
 
-Example: The following configuration options will enable message buffering, and set the buffer duration to 2 seconds.  All messages that occur within 2 seconds of each other (for the same event) will be concatenated into a single slack message.
+
+##### Example
+
+The following configuration options will enable message buffering, and set the buffer duration to 2 seconds. 
+All messages that occur within maximum 2 seconds delay between two neighboring messages will be concatenated into
+a single slack message.
 
 ```
 pm2 set pm2-slack:buffer true
 pm2 set pm2-slack:buffer_seconds 2
 ```
 
+Note: In this example, the maximum total delay for messages is still 60 seconds (default value for `buffer_max_seconds`). After this time, the buffer will be flushed
+everytime and all messages will be sent.
+
+
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code.
 
 ## Release History
-
+- 1.0.0 Message bufferring refactored. Message grouping refactored. Added `servername` option.
+        Added datetime parsing from log messages.
 - 0.3.3 Added documentation for the reload event
 - 0.3.2 Fixed Half width of error and log messages (thanks @ma-zal)
 - 0.3.1 Fixed Double escaping of error and log messages (thanks @ma-zal)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following options are available:
 - username (string) - Set the username used in Slack for posting the message. By default this is the hostname of the server.
 - buffer (bool) - Enable/Disable buffering of messages. Messages that occur in short time will be concatenated together and posted as a single slack message. Default: true
 - buffer_seconds (int) - If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* Default: 1
-- buffer_mas_seconds (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 60
+- buffer_max_seconds (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 60
 - queue_max (int) - Maximum number of messages, that can be send in one Slack message (in one bufferring round). When the queue exceeds this maximum, next messages are suppresesed and replaced with message "`Next XX messages have been suppressed.`". Default: 100
 
 Set these options in the same way you subscribe to events.

--- a/README.md
+++ b/README.md
@@ -43,21 +43,20 @@ The following options are available:
 
 - username (string) - Set the username used in Slack for posting the message. By default this is the hostname of the server.
 - buffer (bool) - Enable/Disable buffering of messages. Messages that occur in short time will be concatenated together and posted as a single slack message. Default: true
-- buffer_seconds (int) - If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* Default: 1
-- buffer_max_seconds (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 60
+- buffer_seconds (int) - If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* Default: 2
+- buffer_max_seconds (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 20
 - queue_max (int) - Maximum number of messages, that can be send in one Slack message (in one bufferring round). When the queue exceeds this maximum, next messages are suppresesed and replaced with message "`Next XX messages have been suppressed.`". Default: 100
 
 Set these options in the same way you subscribe to events.
 
-Example: The following configuration options will enable message buffering, and set the buffer duration to 2 seconds. All messages that occur within maximum 2 seconds delay between two neighboring messages will be concatenated into a single slack message.
+Example: The following configuration options will enable message buffering, and set the buffer duration to 5 seconds. All messages that occur within maximum 5 seconds delay between two neighboring messages will be concatenated into a single slack message.
 
 ```
 pm2 set pm2-slack:username pm2-user
-pm2 set pm2-slack:buffer true
-pm2 set pm2-slack:buffer_seconds 2
+pm2 set pm2-slack:buffer_seconds 5
 ```
 
-Note: In this example, the maximum total delay for messages is still 60 seconds (default value for `buffer_max_seconds`). After this time, the buffer will be flushed
+Note: In this example, the maximum total delay for messages is still 20 seconds (default value for `buffer_max_seconds`). After this time, the buffer will be flushed
 everytime and all messages will be sent.
 
 

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "start": false,
     "online": false,
     "buffer": true,
-    "buffer_seconds": 1,
+    "buffer_seconds": 2,
     "queue_max": 100,
-    "buffer_max_seconds": 60
+    "buffer_max_seconds": 20
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-slack",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "description": "A PM2 module to emit events to Slack",
   "main": "index.js",
   "scripts": {
@@ -44,8 +44,9 @@
     "exit": false,
     "start": false,
     "online": false,
-	"buffer": true,
-	"buffer_seconds": 1,
-	"queue_max": 100
+    "buffer": true,
+    "buffer_seconds": 1,
+    "queue_max": 100,
+    "buffer_max_seconds": 60
   }
 }

--- a/scheduler.js
+++ b/scheduler.js
@@ -31,8 +31,8 @@ var scheduler = {
     },
 
     /**
-     * Plan postponed execution of callback function.
-     * If some plan exists, it will be cancelled.
+     * Plan the postponed execution of callback function.
+     * If some plan exists, it will be cancelled and replaced by the new one.
      * 
      * @param {function} callback
      */

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,0 +1,63 @@
+'use strict';
+
+
+/**
+ * Adds ability to postpone the execution of some function.
+ * If new postpone is requested, old schedule will be cancelling. So max. one schedule can exists in one time.
+ * 
+ * Configuration:
+ * 
+ * - Postponing time is defined in `this.config.buffer_seconds`.
+ * - 
+ */
+var scheduler = {
+    
+    /** @private */
+    _timeoutId: null,
+    
+    /** @private */
+    _totalPostponingSeconds: 0,
+    
+    config: {
+        /**
+         * Postponing time. If it is zero, the callback is always executed immediately. 
+         */
+        buffer_seconds: 0,
+        /**
+         * If is defined, postponning is limited to this total time.
+         * So when the new postponings are request and it will exceed this value, it will be ignored. 
+         */
+        buffer_max_seconds: 60,
+    },
+
+    /**
+     * Plan postponed execution of callback function.
+     * If some plan exists, it will be cancelled.
+     * 
+     * @param {function} callback
+     */
+    schedule: function(callback) {
+        if (this.config.buffer_max_seconds && (this.config.buffer_max_seconds <= this._totalPostponingSeconds + this.config.buffer_seconds)) {
+            // Max buffer time reached. Do not replan sending.
+            return;
+        }
+        
+        // If previous sending is planned, cancel it.        
+        if (this._timeoutId) {
+            clearTimeout(this._timeoutId);
+        }
+        // Plan the message sending after timeout
+        var self = this;
+        this._timeoutId = setTimeout(function() {
+            self._timeoutId = null;
+            self._totalPostponingSeconds = 0;
+            
+            callback();
+        }, this.config.buffer_seconds * 1000);
+        this._totalPostponingSeconds += this.config.buffer_seconds;
+        
+    },
+    
+};
+
+module.exports = scheduler;


### PR DESCRIPTION
Hello.
I **improved the buffering algorithm**. Because I believe this is the good way, I'm offering it to original `pm2-slack` as pull request. You are welcome to discuss about it, of course!

## Goals:
- Reduce number of messages, that comes to Slack (= reduce number of iOS push notifications).
- Solve more intelligent notifications when some service started to continuous failing. Example: Services starts to sending new error message each second.
- No time limitations in buffer's configuration parameters.
- See the appropriate overview in mobile push notification.
- Parsing message's timestamps generated by PM2.

## Implemented algorithm:
1) When new message comes, it is stored to buffer. Buffer starts to wait for interval `buffer_seconds`.
2) If any next messages comes in this interval, it will be also stored to buffer. Buffer will reset previous interval and starts to waiting for new `buffer_seconds`. 
3) When no new message comes in interval `buffer_seconds`, buffer sends the messages to Slack channel.
4) To prevent buffer infinite cycling (when new messages are still received from some application), the buffer will forcibly send the buffered messages after `buffer_max_seconds` (default 60 seconds) interval.