### PR TITLE
Per process custom configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ pm2 set pm2-slack:slack_url https://slack_url
 
 To get the Slack URL, you need to setup an Incoming Webhook. More details on how to set this up can be found here: https://api.slack.com/incoming-webhooks
 
-## Configure
+## Events subscription configuration
 
 The following events can be subscribed to:
 
-- log - All standard out logs from your processes. Default: false
-- error - All error logs from your processes. Default: true
-- kill - Event fired when PM2 is killed. Default: true
-- exception - Any exceptions from your processes. Default: true
-- restart - Event fired when a process is restarted. Default: false
-- reload - Event fired when a cluster is reloaded. Default: false
-- delete - Event fired when a process is removed from PM2. Default: false
-- stop - Event fired when a process is stopped. Default: false
-- restart overlimit - Event fired when a process is reaches the max amount of times it can restart. Default: true
-- exit - Event fired when a process is exited. Default: false
-- start -  Event fired when a process is started. Default: false
-- online - Event fired when a process is online. Default: false
+- `log` - All standard out logs from your processes. Default: false
+- `error` - All error logs from your processes. Default: true
+- `kill` - Event fired when PM2 is killed. Default: true
+- `exception` - Any exceptions from your processes. Default: true
+- `restart` - Event fired when a process is restarted. Default: false
+- `reload` - Event fired when a cluster is reloaded. Default: false
+- `delete` - Event fired when a process is removed from PM2. Default: false
+- `stop` - Event fired when a process is stopped. Default: false
+- `restart overlimit` - Event fired when a process is reaches the max amount of times it can restart. Default: true
+- `exit` - Event fired when a process is exited. Default: false
+- `start` -  Event fired when a process is started. Default: false
+- `online` - Event fired when a process is online. Default: false
 
 You can simply turn these on and off by setting them to true or false using the PM2 set command.
 
@@ -41,40 +41,62 @@ pm2 set pm2-slack:error false
 
 The following options are available:
 
-- servername / username (string) - Set the custom username for Slack messages (visible in message headers). By default this is the hostname of the server.
-- buffer (bool) - Enable/Disable buffering of messages. Messages that occur in short time will be concatenated together and posted as a single slack message. Default: true
-- buffer_seconds (int) - If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* Default: 2
-- buffer_max_seconds (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 20
-- queue_max (int) - Maximum number of messages, that can be send in one Slack message (in one bufferring round). When the queue exceeds this maximum, next messages are suppresesed and replaced with message "`Next XX messages have been suppressed.`". Default: 100
+- `slack_url` (string) - Slack Incomming Webhook URL.
+- `servername` / `username` (string) - Set the custom username for Slack messages (visible in message headers). Default: server hostname
+- `buffer` (bool) - Enable/Disable buffering of messages. Messages that occur in short time will be concatenated together and posted as a single slack message. Default: true
+- `buffer_seconds` (int) - If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* Default: 2
+- `buffer_max_seconds` (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 20
+- `queue_max` (int) - Maximum number of messages, that can be send in one Slack message (in one bufferring round). When the queue exceeds this maximum, next messages are suppresesed and replaced with message "*Next XX messages have been suppressed.*". Default: 100
 
-Set these options in the same way you subscribe to events.
+Set these options in the same way as subscribing to events.
 
-Example: The following configuration options will enable message buffering, and set the buffer duration to 5 seconds. All messages that occur within maximum 5 seconds delay between two neighboring messages will be concatenated into a single slack message.
+
+###### Example
+
+The following configuration options will enable message buffering, and set the buffer duration to 5 seconds. All messages that occur within maximum 5 seconds delay between two neighboring messages will be concatenated into a single slack message.
 
 ```
+pm2 set pm2-slack:slack_url https://hooks.slack.com/services/123456789/123456789/aaaaaaa
 pm2 set pm2-slack:buffer_seconds 5
 ```
 
 Note: In this example, the maximum total delay for messages is still 20 seconds (default value for `buffer_max_seconds`). After this time, the buffer will be flushed
 everytime and all messages will be sent.
 
-### PM2 process based custom configuration
+### Process based custom options
 
-You can define the different Slack URL (and buffer parameters) to each PM2 process.
-Use format `pm2-slack:slack_url-processName` and `pm2-slack:propertyName-processName` in general to process based custom definition.
-If no custom definition exists, the global `pm2-slack:slack_url` (and `pm2-slack:propertyName`) will be used.
+By default, all options are defined for all processes globally.
+But you can separately define custom options to each PM2 process.
+Use format `pm2-slack:optionName-processName` to process based custom options.
+
+If no custom options is defined, the global `pm2-slack:propertyName` will be used.
+
+Note: By this way, all custom options can be used for specific process, but events subsciptions configuration is always global only.
 
 ###### Example
 
+We have many processes, includes process `foo` and process `bar`.
+For this two processes will have to define separate Slack URL channel and separate server name.
+Same buffer options will be used for all processed. 
+
 ```
-# Define global Slack URL for all processes (except the process `foo` and `bar`).
+# Define global options for all processes.
+pm2 set pm2-slack:buffer_seconds 5
+
+# Define global options for all processes.
+#   (for process `foo` and `bar` the values will be overridden below).
 pm2 set pm2-slack:slack_url https://hooks.slack.com/services/123456789/123456789/aaaaaaa
+pm2 set pm2-slack:servername Orion
 
-# Define custom Slack URL for `foo` process.
+# Define custom Slack Incomming Webhoook for `foo` process.
 pm2 set pm2-slack:slack_url-foo https://hooks.slack.com/services/123456789/123456789/bbbbbbb
+pm2 set pm2-slack:servername-foo Foo-server
+# Note: The `pm2-slack:buffer_seconds`=5 will be used from global options for this process. 
 
-# Define custom Slack URL for `bar` process
+# Define custom Slack Incomming Webhoook for `bar` process
 pm2 set pm2-slack:slack_url-bar https://hooks.slack.com/services/123456789/123456789/ccccccc
+pm2 set pm2-slack:servername-foo Bar-server
+# Note: The `pm2-slack:buffer_seconds`=5 will be used from global options for this process. 
 ```
   
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pm2 set pm2-slack:error false
 
 The following options are available:
 
-- username (string) - Set the username used in Slack for posting the message. By default this is the hostname of the server.
+- servername / username (string) - Set the custom username for Slack messages (visible in message headers). By default this is the hostname of the server.
 - buffer (bool) - Enable/Disable buffering of messages. Messages that occur in short time will be concatenated together and posted as a single slack message. Default: true
 - buffer_seconds (int) - If buffering is enables, all messages are stored for this interval. If no new messages comes in this interval, buffered message(s) are sended to Slack. If new message comes in this interval, the "timer" will be reseted and buffer starts waiting for the new interval for a new next message. *Note: Puspose is reduction of push notifications on Slack clients.* Default: 2
 - buffer_max_seconds (int) - If time exceed this time, the buffered messages are always sent to Slack, even if new messages are still comming in interval (property `buffer_seconds`). Default: 20
@@ -52,19 +52,38 @@ Set these options in the same way you subscribe to events.
 Example: The following configuration options will enable message buffering, and set the buffer duration to 5 seconds. All messages that occur within maximum 5 seconds delay between two neighboring messages will be concatenated into a single slack message.
 
 ```
-pm2 set pm2-slack:username pm2-user
 pm2 set pm2-slack:buffer_seconds 5
 ```
 
 Note: In this example, the maximum total delay for messages is still 20 seconds (default value for `buffer_max_seconds`). After this time, the buffer will be flushed
 everytime and all messages will be sent.
 
+### PM2 process based custom configuration
+
+You can define the different Slack URL (and buffer parameters) to each PM2 process.
+Use format `pm2-slack:slack_url-processName` and `pm2-slack:propertyName-processName` in general to process based custom definition.
+If no custom definition exists, the global `pm2-slack:slack_url` (and `pm2-slack:propertyName`) will be used.
+
+###### Example
+
+```
+# Define global Slack URL for all processes (except the process `foo` and `bar`).
+pm2 set pm2-slack:slack_url https://hooks.slack.com/services/123456789/123456789/aaaaaaa
+
+# Define custom Slack URL for `foo` process.
+pm2 set pm2-slack:slack_url-foo https://hooks.slack.com/services/123456789/123456789/bbbbbbb
+
+# Define custom Slack URL for `bar` process
+pm2 set pm2-slack:slack_url-bar https://hooks.slack.com/services/123456789/123456789/ccccccc
+```
+  
 
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code.
 
 ## Release History
+- 1.1.0 Independent Slack URLs can be defined to each PM2 process. 
 - 1.0.0 Message bufferring refactored. Message grouping refactored.
         Added datetime parsing from log messages.
 - 0.3.4 Added an option to override the Slack username

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ pm2 set pm2-slack:servername-foo Bar-server
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code.
 
 ## Release History
-- 1.1.0 Independent Slack URLs can be defined to each PM2 process. 
+- 1.1.0 Custom options can be defined to each PM2 process.
+        Displaying process ID of cluster mode processes (thanks @abawchen). 
 - 1.0.0 Message bufferring refactored. Message grouping refactored.
         Added datetime parsing from log messages.
 - 0.3.4 Added an option to override the Slack username

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const MessageQueue = require('./message-queue');
 
 /**
  * Get the configuration from PM2
- * 
+ *
  * @type {Object}
  * @property {boolean} exception
  */
@@ -19,20 +19,20 @@ const moduleConfig = pmx.initModule();
 /**
  * New PM2 is storing log messages with date in format "YYYY-MM-DD hh:mm:ss +-zz:zz"
  * Parses this date from begin of message
- * 
+ *
  * @param {string} logMessage
  * @returns {{description:string|null, timestamp:number|null}}
  */
 function parseIncommingLog(logMessage) {
     let description = null;
     let timestamp = null;
-    
+
     if (typeof logMessage === "string") {
         // Parse date on begin (if exists)
         const dateRegex = /([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{1,2}:[0-9]{2}:[0-9]{2}(\.[0-9]{3})? [+\-]?[0-9]{1,2}:[0-9]{2}(\.[0-9]{3})?)[:\-\s]+/;
         const parsedDescription = dateRegex.exec(logMessage);
         // Note: The `parsedDescription[0]` is datetime with separator(s) on the end.
-        //       The `parsedDescription[1]` is datetime only (without separators). 
+        //       The `parsedDescription[1]` is datetime only (without separators).
         //       The `parsedDescription[2]` are ".microseconds"
         if (parsedDescription && parsedDescription.length >= 2) {
             // Use timestamp from message
@@ -44,7 +44,7 @@ function parseIncommingLog(logMessage) {
             description = logMessage;
         }
     }
-    
+
     return {
         description: description,
         timestamp: timestamp
@@ -55,7 +55,7 @@ function parseIncommingLog(logMessage) {
 const slackUrlRouter = {
     /**
      * Keys are slackUrls, values are instances of MessageQueue
-     * 
+     *
      * @typedef {Object.<string, MessageQueue>}
      */
     messageQueues: {},
@@ -63,18 +63,18 @@ const slackUrlRouter = {
 
     /**
      * Add the message to appropriate message queue (each Slack URL has own independent message enqueing).
-     *  
+     *
      * @param {Message} message
      */
     addMessage: function(message) {
         const processName = message.name;
         const slackUrl = moduleConfig['slack_url-' + processName] || moduleConfig['slack_url'];
-        
+
         if (!slackUrl) {
             return;
             // No Slack URL defined for this process and no global Slack URL exists.
         }
-        
+
         if (!this.messageQueues[slackUrl]) {
             // Init new messageQueue to different Slack URL.
 
@@ -85,14 +85,26 @@ const slackUrlRouter = {
                 // Use process based custom configuration values if exist, else use the global configuration values.
                 config[configPropertyName] = moduleConfig[configPropertyName + '-' + processName] || moduleConfig[configPropertyName];
             });
-            
+
             this.messageQueues[slackUrl] = new MessageQueue(config);
         }
-        
+
         this.messageQueues[slackUrl].addMessageToQueue(message);
-        
+
     }
 };
+
+
+/**
+ * Get pm2 app display name.
+ * If the app is running in cluster mode, id will append [pm_id] as the suffix.
+ *
+ * @param {object} process
+ * @returns {string} name
+ */
+function parseProcessName(process) {
+    return process.name + (process.exec_mode === 'cluster_mode' && process.instances > 1 ? `[${process.pm_id}]` : '');
+}
 
 
 // ----- APP INITIALIZATION -----
@@ -107,7 +119,7 @@ pm2.launchBus(function(err, bus) {
 
             const parsedLog = parseIncommingLog(data.data);
             slackUrlRouter.addMessage({
-                name: data.process.name,
+                name: parseProcessName(data.process),
                 event: 'log',
                 description: parsedLog.description,
                 timestamp: parsedLog.timestamp,
@@ -122,7 +134,7 @@ pm2.launchBus(function(err, bus) {
 
             const parsedLog = parseIncommingLog(data.data);
             slackUrlRouter.addMessage({
-                name: data.process.name,
+                name: parseProcessName(data.process),
                 event: 'error',
                 description: parsedLog.description,
                 timestamp: parsedLog.timestamp,
@@ -150,7 +162,7 @@ pm2.launchBus(function(err, bus) {
             // If it is instance of Error, use it. If type is unknown, stringify it.
             const description = (data.data && data.data.message) ? (data.data.code || '') + data.data.message :  JSON.stringify(data.data);
             slackUrlRouter.addMessage({
-                name: data.process.name,
+                name: parseProcessName(data.process),
                 event: 'exception',
                 description: description,
                 timestamp: Math.floor(Date.now() / 1000),
@@ -177,7 +189,7 @@ pm2.launchBus(function(err, bus) {
 
         }
         slackUrlRouter.addMessage({
-            name: data.process.name,
+            name: parseProcessName(data.process),
             event: data.event,
             description: description,
             timestamp: Math.floor(Date.now() / 1000),

--- a/index.js
+++ b/index.js
@@ -1,153 +1,19 @@
 'use strict';
 
 // Dependency
-var os = require('os');
-var pm2 = require('pm2');
-var pmx = require('pmx');
-var request = require('request');
-var scheduler = require('./scheduler');
-
-
-// Get the configuration from PM2
-var conf = pmx.initModule();
-
-// The events that will trigger the color red
-var redEvents = ['stop', 'exit', 'delete', 'error', 'kill', 'exception', 'restart overlimit', 'suppressed'];
-var redColor = '#F44336';
-var commonColor = '#2196F3';
-
-// create the message queue
-var globalMessageQueue = [];
+const pm2 = require('pm2');
+const pmx = require('pmx');
+const MessageQueue = require('./message-queue');
 
 
 /**
- * Sends immediately the message(s) to Slack's Incoming Webhook.
+ * Get the configuration from PM2
  * 
- * @param {Message[]) messages - List of messages, ready to send.
- *                              This list can be trimmed and concated base on module configuration.
+ * @type {Object}
+ * @property {boolean} exception
  */
-function sendToSlack(messages) {
 
-    // If a Slack URL is not set, we do not want to continue and nofify the user that it needs to be set
-    if (!conf.slack_url) {
-        return console.error("There is no Slack URL set, please set the Slack URL: 'pm2 set pm2-slack:slack_url https://slack_url'");
-    }
-
-    var limitedCountOfMessages;
-    if (conf.queue_max > 0) {
-        // Limit count of messages for sending
-        limitedCountOfMessages = messages.splice(0, Math.min(conf.queue_max, messages.length));
-    } else {
-        // Select all messages for sending
-        limitedCountOfMessages = messages;
-    }
-
-    // The JSON payload to send to the Webhook
-    var payload = {
-        username: conf.username || os.hostname(),
-        attachments: []
-    };
-
-
-    // Merge together all messages from same process and with same event 
-    // Convert messages to Slack message's attachments
-    payload.attachments = convertMessagesToSlackAttachments(mergeSimilarMessages(limitedCountOfMessages));
-    
-    // Because Slack`s notification text displays the fallback text of first attachment only,
-    // add list of message types to better overview about complex message in mobile notifications.
-    
-    if (payload.attachments.length > 1) {
-        payload.text = payload.attachments
-            .map(function(/*SlackAttachment*/ attachment) { return attachment.title; })
-            .join(", ");
-    }
-
-    // Group together all messages with same title. 
-    // payload.attachments = groupSameSlackAttachmentTypes(payload.attachments);
-
-    // Add warning, if some messages has been suppresed
-    if (messages.length > 0) {
-        var text = 'Next ' + messages.length + ' message' + (messages.length > 1 ? 's have ' : ' has ') + 'been suppressed.';
-        payload.attachments.push({
-            fallback: text,
-            // color: redColor,
-            title: 'message rate limitation',
-            text: text,
-            ts: Math.floor(Date.now() / 1000),
-        });
-    }
-    
-    // Options for the post request
-    var requestOptions = {
-        method: 'post',
-        body: payload,
-        json: true,
-        url: conf.slack_url,
-    };
-
-    // Finally, make the post request to the Slack Incoming Webhook
-    request(requestOptions, function(err, res, body) {
-        if (err) return console.error(err);
-        if (body !== 'ok') {
-            console.error('Error sending notification to Slack, verify that the Slack URL for incoming webhooks is correct. ' + messages.length + ' unsended message(s) lost.');
-        }
-    });
-}
-
-
-/**
- * Sends the message to Slack's Incoming Webhook.
- * If buffer is enabled, the message is added to queue and sending is postponed for couple of seconds.
- * 
- * @param {Message} message
- */
-function scheduleSendToSlack(message) {
-    if (!conf.buffer || !(conf.buffer_seconds > 0)) {
-        // No sending buffer defined. Send directly to Slack.
-        sendToSlack([message]);
-    } else {
-        // Add message to buffer
-        globalMessageQueue.push(message);
-        // Plan send the enqueued messages
-        scheduler.schedule(function() {
-            // Remove waiting messages from global queue
-            const messagesToSend = globalMessageQueue.splice(0, globalMessageQueue.length);
-            
-            sendToSlack(messagesToSend);
-        });
-    }
-}
-
-
-/**
- * Converts messages to json format, that can be sent as Slack message's attachments.
- * 
- * @param {Message[]) messages
- * @returns {SlackAttachment[]}
- */
-function convertMessagesToSlackAttachments(messages) {
-    return messages.reduce(function(slackAttachments, message) {
-    
-        // The default color for events should be green
-        var color = commonColor;
-        // If the event is listed in redEvents, set the color to red
-        if (redEvents.indexOf(message.event) > -1) {
-            color = redColor;
-        }
-        
-        var fallbackText = message.name + ' ' + message.event + (message.description ? ': ' + message.description.trim().replace(/[\r\n]+/g, ', ') : '');
-        slackAttachments.push({
-            fallback: escapeSlackText(fallbackText),
-            color: color,
-            title: escapeSlackText(message.name + ' ' + message.event),
-            text: escapeSlackText(message.description ? message.description.trim() : ''),
-            ts: message.timestamp,
-            // footer: message.name, 
-        });
-        
-        return slackAttachments;
-    }, []);
-}
+const moduleConfig = pmx.initModule();
 
 
 /**
@@ -158,13 +24,13 @@ function convertMessagesToSlackAttachments(messages) {
  * @returns {{description:string|null, timestamp:number|null}}
  */
 function parseIncommingLog(logMessage) {
-    var description = null;
-    var timestamp = null;
+    let description = null;
+    let timestamp = null;
     
     if (typeof logMessage === "string") {
         // Parse date on begin (if exists)
-        var dateRegex = /([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{1,2}:[0-9]{2}:[0-9]{2}(\.[0-9]{3})? [+\-]?[0-9]{1,2}:[0-9]{2}(\.[0-9]{3})?)[:\-\s]+/;
-        var parsedDescription = dateRegex.exec(logMessage);
+        const dateRegex = /([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{1,2}:[0-9]{2}:[0-9]{2}(\.[0-9]{3})? [+\-]?[0-9]{1,2}:[0-9]{2}(\.[0-9]{3})?)[:\-\s]+/;
+        const parsedDescription = dateRegex.exec(logMessage);
         // Note: The `parsedDescription[0]` is datetime with separator(s) on the end.
         //       The `parsedDescription[1]` is datetime only (without separators). 
         //       The `parsedDescription[2]` are ".microseconds"
@@ -186,72 +52,88 @@ function parseIncommingLog(logMessage) {
 }
 
 
-/**
- * Merge together all messages from same process and with same event
- * 
- * @param {Messages[]} messages
- * @returns {Messages[]}
- */
-function mergeSimilarMessages(messages) {
-    return messages.reduce(function(/*Message[]*/ finalMessages, /*Message*/ currentMessage) {
-        if (finalMessages.length > 0
-            && finalMessages[finalMessages.length-1].name === currentMessage.name
-            && finalMessages[finalMessages.length-1].event === currentMessage.event
-        ) {
-            // Current message has same title as previous one. Concate it.
-            finalMessages[finalMessages.length-1].description += "\n" + currentMessage.description;
-        } else {
-            // Current message is different than previous one.
-            finalMessages.push(currentMessage);
+const slackUrlRouter = {
+    /**
+     * Keys are slackUrls, values are instances of MessageQueue
+     * 
+     * @typedef {Object.<string, MessageQueue>}
+     */
+    messageQueues: {},
+
+
+    /**
+     * Add the message to appropriate message queue (each Slack URL has own independent message enqueing).
+     *  
+     * @param {Message} message
+     */
+    addMessage: function(message) {
+        const processName = message.name;
+        const slackUrl = moduleConfig['slack_url-' + processName] || moduleConfig['slack_url'];
+        
+        if (!slackUrl) {
+            return;
+            // No Slack URL defined for this process and no global Slack URL exists.
         }
-        return finalMessages;
-    }, []);
-}
+        
+        if (!this.messageQueues[slackUrl]) {
+            // Init new messageQueue to different Slack URL.
+
+            // Resolve configuration parameters.
+            const configProperties = ['username', 'servername', 'buffer', 'slack_url', 'buffer_seconds', 'buffer_max_seconds', 'queue_max'];
+            const config = {};
+            configProperties.map((configPropertyName) => {
+                // Use process based custom configuration values if exist, else use the global configuration values.
+                config[configPropertyName] = moduleConfig[configPropertyName + '-' + processName] || moduleConfig[configPropertyName];
+            });
+            
+            this.messageQueues[slackUrl] = new MessageQueue(config);
+        }
+        
+        this.messageQueues[slackUrl].addMessageToQueue(message);
+        
+    }
+};
 
 
 // ----- APP INITIALIZATION -----
-
-// Initialize buffer configuration from PM config variables
-scheduler.config.buffer_seconds = Number.parseInt(conf.buffer_seconds); 
-scheduler.config.buffer_max_seconds = Number.parseInt(conf.buffer_max_seconds); 
 
 // Start listening on the PM2 BUS
 pm2.launchBus(function(err, bus) {
 
     // Listen for process logs
-    if (conf.log) {
+    if (moduleConfig.log) {
         bus.on('log:out', function(data) {
-            if (data.process.name !== 'pm2-slack') {
-                var parsedLog = parseIncommingLog(data.data);
-                scheduleSendToSlack({
-                    name: data.process.name,
-                    event: 'log',
-                    description: parsedLog.description,
-                    timestamp: parsedLog.timestamp,
-                });
-            }
+            if (data.process.name === 'pm2-slack') { return; } // Ignore messages of own module.
+
+            const parsedLog = parseIncommingLog(data.data);
+            slackUrlRouter.addMessage({
+                name: data.process.name,
+                event: 'log',
+                description: parsedLog.description,
+                timestamp: parsedLog.timestamp,
+            });
         });
     }
 
     // Listen for process errors
-    if (conf.error) {
+    if (moduleConfig.error) {
         bus.on('log:err', function(data) {
-            if (data.process.name !== 'pm2-slack') {
-                var parsedLog = parseIncommingLog(data.data);
-                scheduleSendToSlack({
-                    name: data.process.name,
-                    event: 'error',
-                    description: parsedLog.description,
-                    timestamp: parsedLog.timestamp,
-                });
-            }
+            if (data.process.name === 'pm2-slack') { return; } // Ignore messages of own module.
+
+            const parsedLog = parseIncommingLog(data.data);
+            slackUrlRouter.addMessage({
+                name: data.process.name,
+                event: 'error',
+                description: parsedLog.description,
+                timestamp: parsedLog.timestamp,
+            });
         });
     }
 
     // Listen for PM2 kill
-    if (conf.kill) {
+    if (moduleConfig.kill) {
         bus.on('pm2:kill', function(data) {
-            scheduleSendToSlack({
+            slackUrlRouter.addMessage({
                 name: 'PM2',
                 event: 'kill',
                 description: data.msg,
@@ -261,78 +143,53 @@ pm2.launchBus(function(err, bus) {
     }
 
     // Listen for process exceptions
-    if (conf.exception) {
+    if (moduleConfig.exception) {
         bus.on('process:exception', function(data) {
-            if (data.process.name !== 'pm2-slack') {
-                // If it is instance of Error, use it. If type is unknown, stringify it.
-                var description = (data.data && data.data.message) ? (data.data.code || '') + data.data.message :  JSON.stringify(data.data);
-                scheduleSendToSlack({
-                    name: data.process.name,
-                    event: 'exception',
-                    description: description,
-                    timestamp: Math.floor(Date.now() / 1000),
-                });
-            }
+            if (data.process.name === 'pm2-slack') { return; } // Ignore messages of own module.
+
+            // If it is instance of Error, use it. If type is unknown, stringify it.
+            const description = (data.data && data.data.message) ? (data.data.code || '') + data.data.message :  JSON.stringify(data.data);
+            slackUrlRouter.addMessage({
+                name: data.process.name,
+                event: 'exception',
+                description: description,
+                timestamp: Math.floor(Date.now() / 1000),
+            });
         });
     }
 
     // Listen for PM2 events
     bus.on('process:event', function(data) {
-        if (conf[data.event]) {
-            if (data.process.name !== 'pm2-slack') {
-                var description = null;
-                switch (data.event) {
-                    case 'start':
-                    case 'stop':
-                    case 'restart':
-                        description = null;
-                        break;
-                        
-                    case 'restart overlimit':
-                        description = 'Process has been stopped. Check and fix the issue.';
-                        break;
-                        
-                }
-                scheduleSendToSlack({
-                    name: data.process.name,
-                    event: data.event,
-                    description: description,
-                    timestamp: Math.floor(Date.now() / 1000),
-                });
-            }
+        if (!moduleConfig[data.event]) { return; } // This event type is disabled by configuration.
+        if (data.process.name === 'pm2-slack') { return; } // Ignore messages of own module.
+
+        let description = null;
+        switch (data.event) {
+            case 'start':
+            case 'stop':
+            case 'restart':
+                description = null;
+                break;
+
+            case 'restart overlimit':
+                description = 'Process has been stopped. Check and fix the issue.';
+                break;
+
         }
+        slackUrlRouter.addMessage({
+            name: data.process.name,
+            event: data.event,
+            description: description,
+            timestamp: Math.floor(Date.now() / 1000),
+        });
     });
 });
-
-
-
-/**
- * Escapes the plain text before sending to Slack's Incoming webhook.
- * @see https://api.slack.com/docs/message-formatting#how_to_escape_characters
- * 
- * @param {string} text
- * @returns {string}
- */
-function escapeSlackText(text) {
-    return (text || '').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-}
-
-
-/**
- * @typedef {Object} SlackAttachment
- * 
- * @property {string} fallback
- * @property {string} title
- * @property {string} [color]
- * @property {string} [text]
- * @property {number} ts - Linux timestamp format
- */
 
 
 /**
  * @typedef {Object} Message
  *
- * @property {string} name
+ * @property {string} name - Process name
  * @property {string} event - `start`|`stop`|`restart`|`error`|`exception`|`restart overlimit`| ...
  * @property {string} description
  * @property {number} timestamp - Linux timestamp format

--- a/message-queue.js
+++ b/message-queue.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// Dependency
+const Scheduler = require('./scheduler');
+const slackSender = require('./slack-sender');
+
+/**
+ * 
+ * @param {Object} config
+ * @param {boolean} config.buffer
+ * @param {number} config.buffer_seconds
+ * @param {number} config.buffer_max_seconds
+ * @param {number} config.queue_max
+ * @param {number} config.slack_url
+ * @constructor
+ */
+function MessageQueue(config) {
+    this.config = config;
+    this.messageQueue = [];
+    this.scheduler = new Scheduler(config);
+}
+
+
+/**
+ * Sends the message to Slack's Incoming Webhook.
+ * If buffer is enabled, the message is added to queue and sending is postponed for couple of seconds.
+ * 
+ * @param {Message} message
+ */
+MessageQueue.prototype.addMessageToQueue = function(message) {
+    const self = this;
+    
+    if (!this.config.buffer || !(this.config.buffer_seconds > 0)) {
+        // No sending buffer defined. Send directly to Slack.
+        slackSender.sendToSlack([message], self.config);
+    } else {
+        // Add message to buffer
+        this.messageQueue.push(message);
+        // Plan send the enqueued messages
+        this.scheduler.schedule(function() {
+            // Remove waiting messages from global queue
+            const messagesToSend = self.messageQueue.splice(0, self.messageQueue.length);
+            
+            slackSender.sendToSlack(messagesToSend, self.config);
+        });
+    }
+    
+}
+
+
+module.exports = MessageQueue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-slack",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A PM2 module to emit events to Slack",
   "main": "index.js",
   "scripts": {
@@ -15,6 +15,9 @@
     "slack"
   ],
   "author": "Matt Atkinson <mattpker@gmail.com> (https://github.com/mattpker)",
+  "contributors": [
+    "Martin Zaloudek (https://github.com/ma-zal)"
+  ],
   "licenses": [
     {
       "type": "MIT",

--- a/scheduler.js
+++ b/scheduler.js
@@ -10,54 +10,54 @@
  * - Postponing time is defined in `this.config.buffer_seconds`.
  * - 
  */
-var scheduler = {
+function Scheduler(config) {
+    const self = this;
     
     /** @private */
-    _timeoutId: null,
+    self._timeoutId = null;
     
     /** @private */
-    _totalPostponingSeconds: 0,
+    self._totalPostponingSeconds = 0;
     
-    config: {
-        /**
-         * Postponing time. If it is zero, the callback is always executed immediately. 
-         */
-        buffer_seconds: 0,
-        /**
-         * If is defined, postponning is limited to this total time.
-         * So when the new postponings are request and it will exceed this value, it will be ignored. 
-         */
-        buffer_max_seconds: 60,
-    },
-
+    
     /**
-     * Plan the postponed execution of callback function.
-     * If some plan exists, it will be cancelled and replaced by the new one.
+     * @property {number} buffer_seconds - Postponing time. If it is zero, the callback is always executed immediately.
      * 
-     * @param {function} callback
+     * @property {number} buffer_max_seconds - If is defined, postponning is limited to this total time.
+     *     So when the new postponings are request and it will exceed this value, it will be ignored. 
      */
-    schedule: function(callback) {
-        if (this.config.buffer_max_seconds && (this.config.buffer_max_seconds <= this._totalPostponingSeconds + this.config.buffer_seconds)) {
-            // Max buffer time reached. Do not replan sending.
-            return;
-        }
-        
-        // If previous sending is planned, cancel it.        
-        if (this._timeoutId) {
-            clearTimeout(this._timeoutId);
-        }
-        // Plan the message sending after timeout
-        var self = this;
-        this._timeoutId = setTimeout(function() {
-            self._timeoutId = null;
-            self._totalPostponingSeconds = 0;
-            
-            callback();
-        }, this.config.buffer_seconds * 1000);
-        this._totalPostponingSeconds += this.config.buffer_seconds;
-        
-    },
-    
+    self.config = config;
 };
 
-module.exports = scheduler;
+
+/**
+ * Plan the postponed execution of callback function.
+ * If some plan exists, it will be cancelled and replaced by the new one.
+ * 
+ * @param {function} callback
+ */
+Scheduler.prototype.schedule = function(callback) {
+    const self = this;
+    
+    if (self.config.buffer_max_seconds && (self.config.buffer_max_seconds <= self._totalPostponingSeconds + self.config.buffer_seconds)) {
+        // Max buffer time reached. Do not replan sending.
+        return;
+    }
+    
+    // If previous sending is planned, cancel it.        
+    if (self._timeoutId) {
+        clearTimeout(this._timeoutId);
+    }
+    // Plan the message sending after timeout
+    self._timeoutId = setTimeout(function() {
+        self._timeoutId = null;
+        self._totalPostponingSeconds = 0;
+        
+        callback();
+    }, self.config.buffer_seconds * 1000);
+    self._totalPostponingSeconds += this.config.buffer_seconds;
+    
+};
+    
+
+module.exports = Scheduler;

--- a/slack-sender.js
+++ b/slack-sender.js
@@ -19,7 +19,7 @@ const commonColor = '#2196F3';
 
 /**
  * Sends immediately the message(s) to Slack's Incoming Webhook.
- * 
+ *
  * @param {Message[]) messages - List of messages, ready to send.
  *                              This list can be trimmed and concated base on module configuration.
  */
@@ -46,20 +46,20 @@ function sendToSlack(messages, config) {
     };
 
 
-    // Merge together all messages from same process and with same event 
+    // Merge together all messages from same process and with same event
     // Convert messages to Slack message's attachments
     payload.attachments = convertMessagesToSlackAttachments(mergeSimilarMessages(limitedCountOfMessages));
-    
+
     // Because Slack`s notification text displays the fallback text of first attachment only,
     // add list of message types to better overview about complex message in mobile notifications.
-    
+
     if (payload.attachments.length > 1) {
         payload.text = payload.attachments
             .map(function(/*SlackAttachment*/ attachment) { return attachment.title; })
             .join(", ");
     }
 
-    // Group together all messages with same title. 
+    // Group together all messages with same title.
     // payload.attachments = groupSameSlackAttachmentTypes(payload.attachments);
 
     // Add warning, if some messages has been suppresed
@@ -73,7 +73,7 @@ function sendToSlack(messages, config) {
             ts: Math.floor(Date.now() / 1000),
         });
     }
-    
+
     // Options for the post request
     const requestOptions = {
         method: 'post',
@@ -94,7 +94,7 @@ function sendToSlack(messages, config) {
 
 /**
  * Merge together all messages from same process and with same event
- * 
+ *
  * @param {Messages[]} messages
  * @returns {Messages[]}
  */
@@ -117,30 +117,32 @@ function mergeSimilarMessages(messages) {
 
 /**
  * Converts messages to json format, that can be sent as Slack message's attachments.
- * 
+ *
  * @param {Message[]) messages
  * @returns {SlackAttachment[]}
  */
 function convertMessagesToSlackAttachments(messages) {
     return messages.reduce(function(slackAttachments, message) {
-    
+
         // The default color for events should be green
-        let color = commonColor;
+        var color = commonColor;
         // If the event is listed in redEvents, set the color to red
         if (redEvents.indexOf(message.event) > -1) {
             color = redColor;
         }
-        
-        const fallbackText = message.name + ' ' + message.event + (message.description ? ': ' + message.description.trim().replace(/[\r\n]+/g, ', ') : '');
+
+        var title = `${message.name} ${message.event}`;
+        var description = (message.description || '').trim();
+        var fallbackText = title + (description ? ': ' + description.replace(/[\r\n]+/g, ', ') : '');
         slackAttachments.push({
             fallback: escapeSlackText(fallbackText),
             color: color,
-            title: escapeSlackText(message.name + ' ' + message.event),
-            text: escapeSlackText(message.description ? message.description.trim() : ''),
+            title: escapeSlackText(title),
+            text: escapeSlackText(description),
             ts: message.timestamp,
-            // footer: message.name, 
+            // footer: message.name,
         });
-        
+
         return slackAttachments;
     }, []);
 }
@@ -149,7 +151,7 @@ function convertMessagesToSlackAttachments(messages) {
 /**
  * Escapes the plain text before sending to Slack's Incoming webhook.
  * @see https://api.slack.com/docs/message-formatting#how_to_escape_characters
- * 
+ *
  * @param {string} text
  * @returns {string}
  */
@@ -160,7 +162,7 @@ function escapeSlackText(text) {
 
 /**
  * @typedef {Object} SlackAttachment
- * 
+ *
  * @property {string} fallback
  * @property {string} title
  * @property {string} [color]

--- a/slack-sender.js
+++ b/slack-sender.js
@@ -1,0 +1,169 @@
+"use strict";
+
+
+// Exports
+module.exports = { sendToSlack };
+
+
+// Dependency
+const request = require('request');
+const os = require('os');
+
+
+// Constants
+// The events that will trigger the color red
+const redEvents = ['stop', 'exit', 'delete', 'error', 'kill', 'exception', 'restart overlimit', 'suppressed'];
+const redColor = '#F44336';
+const commonColor = '#2196F3';
+
+
+/**
+ * Sends immediately the message(s) to Slack's Incoming Webhook.
+ * 
+ * @param {Message[]) messages - List of messages, ready to send.
+ *                              This list can be trimmed and concated base on module configuration.
+ */
+function sendToSlack(messages, config) {
+
+    // If a Slack URL is not set, we do not want to continue and nofify the user that it needs to be set
+    if (!config.slack_url) {
+        return console.error("There is no Slack URL set, please set the Slack URL: 'pm2 set pm2-slack:slack_url https://slack_url'");
+    }
+
+    let limitedCountOfMessages;
+    if (config.queue_max > 0) {
+        // Limit count of messages for sending
+        limitedCountOfMessages = messages.splice(0, Math.min(config.queue_max, messages.length));
+    } else {
+        // Select all messages for sending
+        limitedCountOfMessages = messages;
+    }
+
+    // The JSON payload to send to the Webhook
+    let payload = {
+        username: config.username || config.servername || os.hostname(),
+        attachments: []
+    };
+
+
+    // Merge together all messages from same process and with same event 
+    // Convert messages to Slack message's attachments
+    payload.attachments = convertMessagesToSlackAttachments(mergeSimilarMessages(limitedCountOfMessages));
+    
+    // Because Slack`s notification text displays the fallback text of first attachment only,
+    // add list of message types to better overview about complex message in mobile notifications.
+    
+    if (payload.attachments.length > 1) {
+        payload.text = payload.attachments
+            .map(function(/*SlackAttachment*/ attachment) { return attachment.title; })
+            .join(", ");
+    }
+
+    // Group together all messages with same title. 
+    // payload.attachments = groupSameSlackAttachmentTypes(payload.attachments);
+
+    // Add warning, if some messages has been suppresed
+    if (messages.length > 0) {
+        let text = 'Next ' + messages.length + ' message' + (messages.length > 1 ? 's have ' : ' has ') + 'been suppressed.';
+        payload.attachments.push({
+            fallback: text,
+            // color: redColor,
+            title: 'message rate limitation',
+            text: text,
+            ts: Math.floor(Date.now() / 1000),
+        });
+    }
+    
+    // Options for the post request
+    const requestOptions = {
+        method: 'post',
+        body: payload,
+        json: true,
+        url: config.slack_url,
+    };
+
+    // Finally, make the post request to the Slack Incoming Webhook
+    request(requestOptions, function(err, res, body) {
+        if (err) return console.error(err);
+        if (body !== 'ok') {
+            console.error('Error sending notification to Slack, verify that the Slack URL for incoming webhooks is correct. ' + messages.length + ' unsended message(s) lost.');
+        }
+    });
+}
+
+
+/**
+ * Merge together all messages from same process and with same event
+ * 
+ * @param {Messages[]} messages
+ * @returns {Messages[]}
+ */
+function mergeSimilarMessages(messages) {
+    return messages.reduce(function(/*Message[]*/ finalMessages, /*Message*/ currentMessage) {
+        if (finalMessages.length > 0
+            && finalMessages[finalMessages.length-1].name === currentMessage.name
+            && finalMessages[finalMessages.length-1].event === currentMessage.event
+        ) {
+            // Current message has same title as previous one. Concate it.
+            finalMessages[finalMessages.length-1].description += "\n" + currentMessage.description;
+        } else {
+            // Current message is different than previous one.
+            finalMessages.push(currentMessage);
+        }
+        return finalMessages;
+    }, []);
+}
+
+
+/**
+ * Converts messages to json format, that can be sent as Slack message's attachments.
+ * 
+ * @param {Message[]) messages
+ * @returns {SlackAttachment[]}
+ */
+function convertMessagesToSlackAttachments(messages) {
+    return messages.reduce(function(slackAttachments, message) {
+    
+        // The default color for events should be green
+        let color = commonColor;
+        // If the event is listed in redEvents, set the color to red
+        if (redEvents.indexOf(message.event) > -1) {
+            color = redColor;
+        }
+        
+        const fallbackText = message.name + ' ' + message.event + (message.description ? ': ' + message.description.trim().replace(/[\r\n]+/g, ', ') : '');
+        slackAttachments.push({
+            fallback: escapeSlackText(fallbackText),
+            color: color,
+            title: escapeSlackText(message.name + ' ' + message.event),
+            text: escapeSlackText(message.description ? message.description.trim() : ''),
+            ts: message.timestamp,
+            // footer: message.name, 
+        });
+        
+        return slackAttachments;
+    }, []);
+}
+
+
+/**
+ * Escapes the plain text before sending to Slack's Incoming webhook.
+ * @see https://api.slack.com/docs/message-formatting#how_to_escape_characters
+ * 
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeSlackText(text) {
+    return (text || '').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+}
+
+
+/**
+ * @typedef {Object} SlackAttachment
+ * 
+ * @property {string} fallback
+ * @property {string} title
+ * @property {string} [color]
+ * @property {string} [text]
+ * @property {number} ts - Linux timestamp format
+ */


### PR DESCRIPTION
I implemented possibility to define **custom Slack URL to each process**.

### Manual
- If you would like to override global Slack URL for specific process, define property `pm2-slack:slack_url-processName`.
- If you do not want to send notifications from all processes, do not define the global Slack URL (`pm2-slack:slack_url`)  but custom Slack URLs for specific processed only (`pm2-slack:slack_url-processName`).

Complete documentation: https://github.com/ma-zal/pm2-slack/tree/feat-multiple-slackurl

### Testing

You can install my improved fork by:

    pm2 install ma-zal/pm2-slack#feat-multiple-slackurl

Note: If your PM2 module installation is failing with `#feat-multiple-slackurl` you have older version, that has issue with it. In this case upgrade PM2 first.

### Pull request approval

@mattpker Please do not approve this pull request immediately, Keep time to discussion and testing here. Thanks.
