### PR TITLE
environment support for slack url

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ To install and setup pm2-slack, run the following commands:
 pm2 install pm2-slack
 pm2 set pm2-slack:slack_url https://slack_url
 ```
+Also, you can set any variable though envirouyment, just like this (`docker-compose` example):
+```
+environment: 
+      pm2_slack_slack_url: https://slack_url
+```
 
 To get the Slack URL, you need to setup an Incoming Webhook. More details on how to set this up can be found here: https://api.slack.com/incoming-webhooks
 
@@ -49,6 +54,7 @@ The following options are available:
 - `queue_max` (int) - Maximum number of messages, that can be send in one Slack message (in one bufferring round). When the queue exceeds this maximum, next messages are suppresesed and replaced with message "*Next XX messages have been suppressed.*". Default: 100
 
 Set these options in the same way as subscribing to events.
+Any of them can be set though environment variable `pm2_slack_{option_name}`.
 
 
 ###### Example

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const slackUrlRouter = {
      */
     addMessage: function(message) {
         const processName = message.name;
-        const slackUrl = moduleConfig['slack_url-' + processName] || moduleConfig['slack_url'];
+        const slackUrl = moduleConfig['slack_url-' + processName] || moduleConfig['slack_url'] || process.env.pm2_slack_slack_url;
 
         if (!slackUrl) {
             return;
@@ -83,7 +83,7 @@ const slackUrlRouter = {
             const config = {};
             configProperties.map((configPropertyName) => {
                 // Use process based custom configuration values if exist, else use the global configuration values.
-                config[configPropertyName] = moduleConfig[configPropertyName + '-' + processName] || moduleConfig[configPropertyName];
+                config[configPropertyName] = moduleConfig[configPropertyName + '-' + processName] || process.env['pm2_slack_'+configPropertyName];
             });
 
             this.messageQueues[slackUrl] = new MessageQueue(config);


### PR DESCRIPTION
added environment support for all config properties, they can beset by passing
pm2_slack_{prop_name}
to env